### PR TITLE
chore(release): bump version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mutex",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mutex",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "dependencies": {
         "@actions/core": "^3.0.0",
         "@actions/github": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mutex",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "description": "Advisory lock service for CI/CD pipelines. Prevents race conditions by ensuring mutual exclusion: only one job can access shared resources concurrently.",
   "main": "lib/main.js",


### PR DESCRIPTION
Version bump ahead of tagging `v1.1.0`. This repo keeps `package.json` in sync
with the release tag (1.0.0 @ `v1.0.0`, 1.0.1 @ `v1.0.1`), so this needs to land
before the tag is cut.

## Why minor, not patch

37 commits since `v1.0.1`. The substantive one is #42 (migrate to ESM, bump
`@actions/github` to v9), followed by dependency majors: `@actions/core` v3,
`@slack/web-api` v8, `typescript` v6, `jest` v30.

## Why not major

`action.yaml` is byte-identical to `v1.0.1` — same inputs, same outputs, still
`using: "node24"`. Nothing changes for consumers of `releasetools/mutex@v1`.

Only `package.json` and `package-lock.json` change here; `dist/` and `lib/` are
already current at `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)