### PR TITLE
fix(ci): verify the published v1 tag instead of a pinned digest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,44 @@ jobs:
           npm run lint
           npm test
 
-  e2e-test:
+  # 'uses:' is resolved during "Set up job", before the first step runs, so a
+  # sleep step inside e2e-test would be too late — the action is already
+  # downloaded. The wait has to be its own job that e2e-test depends on.
+  await-v1:
     runs-on: ubuntu-latest
     needs: build-and-test
+    permissions:
+      contents: read
+    steps:
+      - name: ⏳ Wait for v1 to point at this release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in $(seq 1 30); do
+            object_type="$(gh api "repos/${{ github.repository }}/git/ref/tags/v1" --jq '.object.type')"
+            sha="$(gh api "repos/${{ github.repository }}/git/ref/tags/v1" --jq '.object.sha')"
+
+            # v1 is an annotated tag, so the ref points at a tag object; deref it
+            # to the commit it wraps.
+            if [ "$object_type" = "tag" ]; then
+              sha="$(gh api "repos/${{ github.repository }}/git/tags/$sha" --jq '.object.sha')"
+            fi
+
+            if [ "$sha" = "${{ github.sha }}" ]; then
+              echo "v1 -> $sha"
+              exit 0
+            fi
+
+            echo "attempt $attempt/30: v1 -> $sha, waiting for ${{ github.sha }}"
+            sleep 10
+          done
+
+          echo "::error::v1 still does not point at ${{ github.sha }} after 5 minutes. Was the release cut without --major?"
+          exit 1
+
+  e2e-test:
+    runs-on: ubuntu-latest
+    needs: [build-and-test, await-v1]
     permissions:
       contents: read
       pull-requests: write
@@ -31,8 +66,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # Deliberately references the moving v1 tag rather than a pinned digest:
+      # this step exists to verify the release consumers actually get from
+      # releasetools/mutex@v1. Renovate bumps the digest only *after* a release
+      # (see #63), so a pin is always one release stale at the moment this
+      # workflow runs — exactly when the check matters. 'uses:' cannot take an
+      # expression such as ${{ github.ref_name }} either; it is one of the few
+      # keys that does not accept contexts. The await-v1 job above guarantees v1
+      # has already moved. renovate.json keeps Renovate from re-pinning this.
       - name: 🔒 Acquire Lock (and auto-release on completion)
-        uses: releasetools/mutex@6a595e2a356989f10d49bc2d45032fd06a059a8c # v1
+        uses: releasetools/mutex@v1
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,13 @@
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 5am on monday"]
-  }
+  },
+  "packageRules": [
+    {
+      "description": "release.yaml must reference the moving releasetools/mutex@v1 tag so it verifies the release that was just published. helpers:pinGitHubActionDigests pinned it in #43 and re-pinned it in #63; because the digest bump only lands after a release, a pin is always one release stale at the moment the release workflow runs.",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["releasetools/mutex"],
+      "pinDigests": false
+    }
+  ]
 }


### PR DESCRIPTION
The `e2e-test` job in `release.yaml` pinned the action to
`releasetools/mutex@c43feb89589aa9acd7b35652ab0338fe04b17126 # v1`, so the step
labelled *"Verify released v1 version"* exercised whichever commit `v1` pointed
at **before** the release — not the one just published.

This surfaced during v1.1.0: `v1` moved `c43feb89` → `6a595e2`, and the release
workflow that ran on the `v1.1.0` tag passed while testing v1.0.1-era code.

## Root cause

The line was originally correct:

```
-        uses: releasetools/mutex@v1
+        uses: releasetools/mutex@c43feb89589aa9acd7b35652ab0338fe04b17126 # v1
```

That is #43 — Renovate's `helpers:pinGitHubActionDigests` pinning the repo's own
self-reference. Digest pinning is right for third-party actions and wrong for
this one line, where the moving tag *is* the thing under test.

## Changes

**1. Restore the moving tag** — `uses: releasetools/mutex@v1`, so the job
verifies what a consumer actually resolves.

**2. Stop Renovate re-pinning it.** Without this the digest returns on the next
run. Scoped to this dep only, so every other action stays pinned:

```json
{
  "matchManagers": ["github-actions"],
  "matchDepNames": ["releasetools/mutex"],
  "pinDigests": false
}
```

`pinDigests: false` rather than `enabled: false`, so a future `v1` → `v2` bump
is still offered.

**3. Wait for `v1` to move, in a separate job.** There is a race: `rt
git::release --major --push` pushes `v1.1.0` first, which triggers this
workflow, then force-pushes `v1`. If the e2e job resolves `@v1` before that
second push lands, it silently tests the old commit again.

A sleep *step* cannot fix this. Verified against the v1.1.0 run — the action is
downloaded during **Set up job**, before the first step executes:

```
e2e-test  Set up job     23:41:04.9  Download action repository 'releasetools/mutex@c43feb89...'
e2e-test  Checkout code  23:41:05.6  (first step begins)
```

So the wait is its own job that `e2e-test` now depends on. It polls the `v1` ref
instead of sleeping a fixed interval — dereferencing the annotated tag to its
commit and comparing against `github.sha` — and fails after 5 minutes if `v1`
never moved, which also catches a release cut without `--major`.

The deref logic is verified against the live API:

```
ref object type=tag sha=110617cd04fb7bcd51007831f35ccd786641e950
deref'd commit: 6a595e2a356989f10d49bc2d45032fd06a059a8c
release commit: 6a595e2a356989f10d49bc2d45032fd06a059a8c  -> MATCH
```

## Why not `uses: ./`

An earlier revision of this PR used `./`. It tests the right *code*, but not the
published `@v1` reference — and verifying that tag resolves is the entire point
of this job. It also duplicated `test.yaml`. Discarded.

## Note on the first release after merge

`v1` currently points at `6a595e2`, so `await-v1` passes today. On the next
release the poll does the real work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)